### PR TITLE
Added functionality to uplaod file in MTU sized chunks

### DIFF
--- a/src/frameutils/bluetooth.py
+++ b/src/frameutils/bluetooth.py
@@ -207,18 +207,41 @@ class Bluetooth:
         """
         await self._transmit(bytearray(b"\x03"), show_me=show_me)
 
-    async def upload_file(self, file, file_name="main.lua"):
+    async def upload_file(self, file: str, file_name="main.lua"):
         """
         Uploads a file as file_name. If the file exists, it will be overwritten.
         """
 
         await self.send_break_signal()
 
-        await self.send_lua(
-            f"f=frame.file.open('{file_name}','w');print(nil)", await_print=True
-        )
+        if os.path.exists(file):
+            with open(file, 'r') as f:
+                file = f.read()
 
-        for line in file.splitlines():
-            await self.send_lua(f'f:write("{line}\\n");print(nil)', await_print=True)
+        file = file.replace('\\', '\\\\')
+        file = file.replace("\n", "\\n")
+        file = file.replace("'", "\\'")
+        file = file.replace('"', '\\"')
+
+        await self.send_lua(f"f=frame.file.open('{file_name}','w');print(nil)",
+                            await_print=True)
+
+        index: int = 0
+        chunkSize: int = self.max_data_payload() - 22
+
+        while index < len(file):
+            if index + chunkSize > len(file):
+                chunkSize = len(file) - index
+
+            # Don't split on an escape character
+            if file[index + chunkSize - 1] == '\\':
+                chunkSize -= 1
+
+            chunk: str = file[index:index + chunkSize]
+
+            await self.send_lua(f'f:write("{chunk}\\n");print(nil)',
+                                await_print=True)
+
+            index += chunkSize
 
         await self.send_lua("f:close();print(nil)", await_print=True)


### PR DESCRIPTION
Instead of uploading file line by line, it's more efficient to upload in MTU sized chunks. The logic for this code has directly been picked from the Noa flutter app implementation. Also adds the functionality to read the file contents from a file path if the user has provided that instead (line 217 - 219).